### PR TITLE
Correct Thinkmoda capitalization on landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,7 +259,7 @@ export default function SignInPage() {
 
         {/* Footer */}
         <div className="text-center text-sm text-gray-500">
-          <p>© 2025 Thinkmoda. All rights reserved.</p>
+          <p>© 2025 ThinkMODA. All rights reserved.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Capitalize "MODA" in the copyright notice on the landing page as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4b745f4-0fc5-40dd-bfb5-d001623a4104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4b745f4-0fc5-40dd-bfb5-d001623a4104">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>